### PR TITLE
fixes #9

### DIFF
--- a/Blesmol Core/Unit.cs
+++ b/Blesmol Core/Unit.cs
@@ -2,12 +2,17 @@
 
 namespace Blesmol.Core {
 	public static class Units {
-		public static Int64 ConvertFromBytes(Int64 bytes, Unit unit) => bytes > 0 ? bytes / (Int64)unit : 0;
+		private static Int64 TryConvert(Int64 bytes, Unit unit, Func<Int64, Units.Unit, Int64> convert) =>
+			unit == Unit.Percentage ? throw new ArgumentOutOfRangeException("Unit.Percentage is not supported for byte conversion")
+									: bytes < 0 ? throw new ArgumentOutOfRangeException("byte count must be greater than or equal to 0")
+												: convert(bytes, unit);
 
-		public static Int64 ConvertToBytes(Int64 bytes, Unit unit) => bytes * (Int64)unit;
+		public static Int64 ConvertFromBytes(Int64 bytes, Unit unit) => TryConvert(bytes, unit, (b, u) => b / (Int64)u);
+
+		public static Int64 ConvertToBytes(Int64 bytes, Unit unit) => TryConvert(bytes, unit, (b, u) => b * (Int64)u);
 
 		public enum Unit : Int64 {
-			Percentage = 0,
+			Percentage = -1,
 			B = 1,
 			KB = 1024,
 			MB = 1048576,

--- a/Blesmol Frontend/FrmMain.cs
+++ b/Blesmol Frontend/FrmMain.cs
@@ -14,7 +14,7 @@ namespace Blesmol {
 		private readonly Boolean _FormLoaded = false;
 		private readonly ISettings Settings;
 		private Int32 defaultThresholdAmount = 0;
-		private Units.Unit defaultThresholdUnit = default;
+		private Units.Unit defaultThresholdUnit = Units.Unit.GB;
 		private Int32 defaultSleepInterval = 5;
 		private Int32 defaultAlertInterval = 45;
 		private Int32 defaultSmtpServerPort = 25;
@@ -151,7 +151,7 @@ namespace Blesmol {
 			}
 
 			txtAmount.Text = (Settings?.Threshold?.Amount ?? defaultThresholdAmount).ToString();
-			cboUnit.SelectedValue = Settings.Threshold?.Unit ?? defaultThresholdUnit;
+			cboUnit.SelectedValue = Settings.Threshold?.Unit != null && Settings.Threshold.Unit != default ? Settings.Threshold.Unit : defaultThresholdUnit;
 
 			txtMachineName.Text = coalesceString(Settings?.Email?.MachineName) ?? System.Windows.Forms.SystemInformation.ComputerName;
 			txtSmtpServer.Text = coalesceString(Settings?.Email?.SmtpServer) ?? "127.0.0.1";

--- a/Blesmol Registry/ThresholdSettings.cs
+++ b/Blesmol Registry/ThresholdSettings.cs
@@ -7,7 +7,7 @@ namespace Blesmol.Registry {
 
 		private readonly ISetting Amount;
 		Int32? IThresholdSettings.Amount {
-			get => (Int32)Amount.Value;
+			get => (Int32?)Amount.Value;
 			set => Amount.Value = value;
 		}
 


### PR DESCRIPTION
also fixed a null reference issue with ThresholdSettings when the key isn't yet set, and reenabled the ui to set any unit as the default selection.